### PR TITLE
Remove unused install routine and clarify dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 pandas
 numpy
 openpyxl
+requests

--- a/src/scott_code.py
+++ b/src/scott_code.py
@@ -12,13 +12,6 @@ import time
 
 
 
-## 2. Install Dependencies (if running in Colab)
-def install_dependencies():
-    """Placeholder to maintain compatibility with the original notebook."""
-    pass
-
-
-
 ## 3. Helper Functions
 ### 3.1 Fetch data from URLs
 def download_file(url, save_path):
@@ -531,13 +524,14 @@ def setup_year_data(year):
 ## 5. Main Execution
 ### 5.1 Main entry point
 
-# Mount Google Drive
-
-
 ### Notes: Downloaded generator data, demand data and flow data is all in MW
 
 def main():
-    install_dependencies()
+
+    # Simple runtime check for required packages
+    import importlib
+    for pkg in ["pandas", "numpy", "requests", "openpyxl"]:
+        importlib.import_module(pkg)
 
     # Get emission rates
     emission_rates = get_emission_rates()


### PR DESCRIPTION
## Summary
- drop the unused `install_dependencies` function
- remove obsolete Google Drive comment
- enforce package checks at runtime
- add `requests` to `requirements.txt`

## Testing
- `python -m py_compile src/*.py`

------
https://chatgpt.com/codex/tasks/task_e_68681264df8c83249d8babe1c218c9ad