### PR TITLE
Replace interactive inputs with argparse

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This repository processes IESO data to compute electricity emission factors for 
    python src/emission_factors.py
 
    # Converted analysis from Scott_Code_Feb2025.ipynb
-   python src/scott_code.py
+   python src/scott_code.py --year 2022 --emission-rate 'Natural Gas=500'
    ```
 
 A simple GitHub Actions workflow is provided to demonstrate running the script automatically on each push.


### PR DESCRIPTION
## Summary
- remove all `input()` prompts from scott_code.py
- add an argparse CLI for year selection and emission rate overrides
- keep defaults when arguments are omitted
- update README usage example

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686812684e8c83249c0e0e004a4187d2