### PR TITLE
Fix trade flow transformation in SubOntario_EF_Code

### DIFF
--- a/src/SubOntario_EF_Code.py
+++ b/src/SubOntario_EF_Code.py
@@ -171,6 +171,7 @@ def setup_year_data(year: int):
     trade_path = os.path.join(trade_dir, f"PUB_IntertieScheduleFlowYear_{year}.csv")
     download_file(trade_url, trade_path)
     trade_df = parse_and_clean_trade_flow(trade_path)
+    trade_df = transform_trade_flow(trade_df)
 
     return gen_df, demand_df, zonal_df, trade_df
 


### PR DESCRIPTION
## Summary
- ensure trade flow data is transformed in `setup_year_data`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686fd56cdb108324b6180454853bfa03